### PR TITLE
Fix: Use timezone-aware datetime and correct ISO formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dev = [
     "pytest>=7.4.0",
     "pytest-cov>=4.1.0",
     "isort>=5.12.0",
+    "httpx>=0.26.0", # Added for TestClient
 ]
 
 [build-system]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,7 +8,7 @@ from uuid import UUID
 import pytest
 from fastapi.testclient import TestClient
 
-from main import app, COMMENTS_DIR
+from main import app
 
 
 @pytest.fixture
@@ -18,59 +18,89 @@ def client():
 
 
 @pytest.fixture(autouse=True)
-def setup_and_teardown():
+def setup_and_teardown_env(monkeypatch):
     """Set up test environment before each test and clean up after."""
-    # Create temporary comments directory for tests
-    test_comments_dir = Path("test_comments")
-    test_comments_dir.mkdir(exist_ok=True)
+    base_test_dir = Path("test_temp_data")
     
-    # Backup original comments directory path
-    original_comments_dir = COMMENTS_DIR
-    
-    # Override the comments directory for testing
-    global COMMENTS_DIR
-    COMMENTS_DIR = test_comments_dir
+    test_data_dir = base_test_dir / "slag-data"
+    test_comments_dir = test_data_dir / "comments"
+    test_targets_dir = test_data_dir / "targets"
+    test_flags_dir = test_data_dir / "flags"
+    test_snapshot_file = test_data_dir / "snapshot.json"
+
+    test_comments_dir.mkdir(parents=True, exist_ok=True)
+    test_targets_dir.mkdir(parents=True, exist_ok=True)
+    test_flags_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr("main.DATA_DIR", test_data_dir)
+    monkeypatch.setattr("main.COMMENTS_DIR", test_comments_dir)
+    monkeypatch.setattr("main.TARGETS_DIR", test_targets_dir)
+    monkeypatch.setattr("main.FLAGS_DIR", test_flags_dir)
+    monkeypatch.setattr("main.SNAPSHOT_FILE", test_snapshot_file)
     
     yield
     
-    # Clean up test directory after tests
-    if test_comments_dir.exists():
-        shutil.rmtree(test_comments_dir)
-    
-    # Restore original comments directory
-    COMMENTS_DIR = original_comments_dir
+    if base_test_dir.exists():
+        shutil.rmtree(base_test_dir)
 
+
+from datetime import datetime, timezone # Added for timestamp check
+import re # For regex matching of timestamp
 
 def test_read_root(client):
     """Test the root endpoint."""
     response = client.get("/")
     assert response.status_code == 200
-    assert "SLAG Commenting System" in response.json()["name"]
+    assert response.json()["name"] == "SLAG Commenting API" # Adjusted to actual name
 
 
 def test_create_and_get_comment(client):
     """Test creating and retrieving a comment."""
-    # Create a new comment
-    page_id = "test-page-1"
-    comment_data = {
-        "author": "Test User",
-        "text": "This is a test comment."
+    target_id = "test-target-1"
+    comment_input_data = {
+        "content": "This is a test comment.",
+        "attributedTo": {
+            "id": "http://example.com/users/testuser",
+            "name": "Test User",
+            "type": "Person"
+        }
     }
     
-    response = client.post(f"/comments/{page_id}", json=comment_data)
-    assert response.status_code == 201
-    
-    # Get the comment UUID
-    comment_uuid = response.json()["uuid"]
-    
-    # Verify the UUID is valid
-    UUID(comment_uuid)
-    
-    # Retrieve all comments for the page
-    response = client.get(f"/comments/{page_id}")
+    # Create a new comment
+    response = client.post(f"/comments/{target_id}", json=comment_input_data)
+    assert response.status_code == 200 # FastAPI default for POST with response model
+
+    created_comment = response.json()
+    assert created_comment["content"] == comment_input_data["content"]
+    assert created_comment["attributedTo"]["name"] == comment_input_data["attributedTo"]["name"]
+    assert "id" in created_comment
+    comment_id_url = created_comment["id"]
+    assert comment_id_url.startswith("https://slag.example.com/comments/")
+
+    # Check the published field
+    assert "published" in created_comment
+    published_timestamp = created_comment["published"]
+    # Example: 2024-01-11T10:40:09.123456Z
+    assert re.match(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$", published_timestamp)
+    # Further check: parse it back to a datetime object
+    dt_obj = datetime.fromisoformat(published_timestamp.replace("Z", "+00:00"))
+    assert dt_obj.tzinfo == timezone.utc
+
+    # Retrieve the comment directly by its ULID
+    ulid_id = comment_id_url.split("/")[-1]
+    response = client.get(f"/comment/{ulid_id}")
     assert response.status_code == 200
-    assert len(response.json()["comments"]) == 1
-    assert response.json()["comments"][0]["text"] == "This is a test comment."
+    retrieved_comment = response.json()
+    assert retrieved_comment["content"] == comment_input_data["content"]
+    assert retrieved_comment["published"] == published_timestamp
+
+    # Retrieve all comments for the target
+    response = client.get(f"/comments/{target_id}")
+    assert response.status_code == 200
+    collection = response.json()
+    assert collection["totalItems"] == 1
+    assert len(collection["orderedItems"]) == 1
+    assert collection["orderedItems"][0] == comment_id_url
 
 
 def test_update_comment(client):


### PR DESCRIPTION
- Replaced deprecated `datetime.utcnow()` with `datetime.now(timezone.utc)`.
- Updated Pydantic serialization to use `model_dump(mode='json')` for compatibility with `json.dump` and correct serialization of types like `HttpUrl` and `datetime`.
- Ensured the `published` field in comments is stored as an ISO 8601 string with a 'Z' suffix (e.g., `YYYY-MM-DDTHH:MM:SS.ffffffZ`).
- Added `httpx` to dev dependencies for `TestClient`.
- Patched test environment setup in `tests/test_main.py` to use `monkeypatch` and correctly manage test data directories.
- Updated `test_read_root` and `test_create_and_get_comment` to align with current API responses and to verify the new datetime format.

Note: Several other tests in `tests/test_main.py` (test_update_comment, test_delete_comment, test_create_and_get_reply) are still failing as they appear outdated and inconsistent with the current API contract. These were not updated as part of this focused fix.